### PR TITLE
Small improvements to Data Request Form

### DIFF
--- a/.github/ISSUE_TEMPLATE/data_request.yaml
+++ b/.github/ISSUE_TEMPLATE/data_request.yaml
@@ -17,7 +17,7 @@ body:
       placeholder:
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: description
     attributes:
       label: Dataset Description     
@@ -33,7 +33,7 @@ body:
       placeholder:
     validations:
       required: true
-  - type: input
+  - type: textarea
     id: method
     attributes:
       label: Platform/Method/Sensor

--- a/.github/ISSUE_TEMPLATE/data_request.yaml
+++ b/.github/ISSUE_TEMPLATE/data_request.yaml
@@ -74,6 +74,14 @@ body:
     validations:
       required: true
   - type: input
+    id: format
+    attributes:
+      label: Format of the Data
+      description: What format is this data stored in ? e.g. netCDF4, HDF5, GeoTIFF, Cloud Optimized GeoTIFF, Zarr, etc.
+      placeholder:
+    validations:
+      required: false
+  - type: input
     id: size
     attributes:
       label: Approximate Size of the Data


### PR DESCRIPTION
I simulated the usage of the form for the ESA CCI dataset and I suggest the following improvements :

- I found that the space for description and method/platform was too small with the type `input` -- if the user types more than 5 words he/she has to scroll horizontally to visualize the text, which makes for a poor user experience. I think that description and method can typically be longer than that, so I suggest to make that larger by switching to the `textarea` type like we did already for a couple other entries.
- Added a data format optional entry.